### PR TITLE
Tightens timing slightly

### DIFF
--- a/src/TriacDimmer.cpp
+++ b/src/TriacDimmer.cpp
@@ -85,6 +85,13 @@ ISR(TIMER1_CAPT_vect){
 	static uint16_t last_icr = 0;
 	TriacDimmer::detail::period = ICR1 - last_icr;
 	last_icr = ICR1;
+
+	if((signed)(TCNT1 - OCR1A) >= 0){
+		TCCR1C = _BV(FOC1A); //interrupt ran late, trigger match manually
+	}
+	if((signed)(TCNT1 - OCR1B) >= 0){
+		TCCR1C = _BV(FOC1B); //interrupt ran late, trigger match manually
+	}
 }
 
 

--- a/src/TriacDimmer.cpp
+++ b/src/TriacDimmer.cpp
@@ -35,7 +35,7 @@ void TriacDimmer::end(){
 void TriacDimmer::setBrightness(uint8_t pin, float value){
 	assert(pin == 9 || pin == 10);
 
-	if (pin & 0x01 == 0x01){ // if (pin == 9){
+	if ((pin & 0x01) == 0x01){ // if (pin == 9){
 		TriacDimmer::detail::setChannelA(1 - value);
 	} else { // if (pin == 10){
 		TriacDimmer::detail::setChannelB(1 - value);
@@ -45,7 +45,7 @@ void TriacDimmer::setBrightness(uint8_t pin, float value){
 float TriacDimmer::getCurrentBrightness(uint8_t pin){
 	assert(pin == 9 || pin == 10);
 	
-	if (pin & 0x01 == 0x01){ // if (pin == 9){
+	if ((pin & 0x01) == 0x01){ // if (pin == 9){
 		1 - TriacDimmer::detail::getChannelA();
 	} else { // if (pin == 10){
 		1 - TriacDimmer::detail::getChannelB();


### PR DESCRIPTION
The late guards are to reduce flickering for brightness values very close to 0 or 1.