### PR TITLE
Configure output compare behavior correctly.

### DIFF
--- a/src/TriacDimmer.cpp
+++ b/src/TriacDimmer.cpp
@@ -97,7 +97,7 @@ ISR(TIMER1_CAPT_vect){
 
 ISR(TIMER1_COMPA_vect){
 	TIMSK1 &=~ _BV(OCIE1A); //disable match interrupt
-	TCCR1A |= _BV(COM1A1); //clear OC1x on compare match
+	TCCR1A &=~ _BV(COM1A0); //clear OC1x on compare match
 
 	OCR1A = ICR1 + TriacDimmer::detail::ch_A_dn;
 
@@ -109,7 +109,7 @@ ISR(TIMER1_COMPA_vect){
 
 ISR(TIMER1_COMPB_vect){
 	TIMSK1 &=~ _BV(OCIE1B); //disable match interrupt
-	TCCR1A |= _BV(COM1B1); //clear OC1x on compare match
+	TCCR1A &=~ _BV(COM1B0); //clear OC1x on compare match
 
 	OCR1B = ICR1 + TriacDimmer::detail::ch_B_dn;
 

--- a/src/TriacDimmer.cpp
+++ b/src/TriacDimmer.cpp
@@ -71,7 +71,7 @@ float TriacDimmer::detail::getChannelB(){
 
 ISR(TIMER1_CAPT_vect){
 	TIMSK1 &=~ (_BV(OCIE1A) | _BV(OCIE1B)); //clear interrupts, in case they haven't run yet
-	TCCR1A &=~ (_BV(COM1A1) | _BV(COM1B1));
+	TCCR1A &=~ (_BV(COM1A0) | _BV(COM1B0));
 	TCCR1C = _BV(FOC1A) | _BV(FOC1B); //ensure outputs are properly cleared
 
 	OCR1A = ICR1 + TriacDimmer::detail::ch_A_up;


### PR DESCRIPTION
The timers should now correctly output a short pulse.

Resolves #12.